### PR TITLE
Fix import / namespace issues resulting 

### DIFF
--- a/src/Craftpageexporter.php
+++ b/src/Craftpageexporter.php
@@ -28,6 +28,7 @@ use lhs\craftpageexporter\models\Settings;
 use lhs\craftpageexporter\models\transformers\AssetTransformer;
 use lhs\craftpageexporter\models\transformers\PathAndUrlTransformer;
 use lhs\craftpageexporter\services\CraftpageexporterService;
+use lhs\craftpageexporter\variables\PageExporterVariable;
 use yii\base\Event;
 
 /**

--- a/src/variables/PageExporterVariable.php
+++ b/src/variables/PageExporterVariable.php
@@ -4,7 +4,7 @@ namespace lhs\craftpageexporter\variables;
 
 
 use craft\helpers\Template;
-
+use lhs\craftpageexporter\Craftpageexporter;
 
 class PageExporterVariable
 {


### PR DESCRIPTION
The change to fix composer 2.0 / PSR-4 autoloading compatibility that was introduced in be6174a is incomplete, in that it changes the namespace for PageExporterVariable without updating the relevant `use` statement that imports the variable into the plugin base class to expose it, and conversely is also missing an import of the plugin base class into the variable class.

This PR fixes those issues so that the plugin work again while also being compatible with Composer 2