### PR TITLE
Use Craft's Guzzle Client

### DIFF
--- a/src/services/Export.php
+++ b/src/services/Export.php
@@ -79,7 +79,7 @@ class Export extends Component
      */
     protected function getEntryContent($entry)
     {
-        $client = new Client();
+        $client = Craft::createGuzzleClient();
         $response = $client->get(UrlHelper::urlWithParams($entry->getUrl(), [
             'pageExporterContext' => 1,
         ]));


### PR DESCRIPTION
Instead of creating a Guzzle client directly from the Guzzle library, use Craft's `guzzleCreateClient()`. This creates a client with custom configuration found in `config/guzzle.php`.

Fixes #36 